### PR TITLE
Set screen oriantation

### DIFF
--- a/ili9225.h
+++ b/ili9225.h
@@ -50,3 +50,7 @@ void lcdUnsetFontFill(void);
 void lcdSetFontUnderLine(uint16_t color);
 void lcdUnsetFontUnderLine(void);
 
+uint16_t _width;
+uint16_t _height;
+uint16_t _FONT_DIRECTION_;
+uint16_t _SCREEN_DIRECTION_;

--- a/ili9225.h
+++ b/ili9225.h
@@ -23,6 +23,8 @@ void lcdWriteColor(uint16_t color, uint16_t size);
 void lcdInit(int width, int height, int offsetx, int offsety);
 void lcdReset(void);
 void lcdSetup(void);
+void lcdRotCoord(uint16_t *x, uint16_t *y);
+void lcdRotSqCoord(uint16_t *x1, uint16_t *y1, uint16_t *x2, uint16_t *y2);
 void lcdDrawPixel(uint16_t x, uint16_t y, uint16_t color);
 void lcdDrawFillRect(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void lcdDisplayOff(void);
@@ -42,6 +44,7 @@ int lcdDrawSJISChar(FontxFile *fx, uint16_t x,uint16_t y,uint16_t sjis,uint16_t 
 int lcdDrawUTF8Char(FontxFile *fx, uint16_t x,uint16_t y,uint8_t *utf8,uint16_t color);
 int lcdDrawUTF8String(FontxFile *fx, uint16_t x,uint16_t y,uint8_t *utfs,uint16_t color);
 void lcdSetFontDirection(uint16_t);
+void lcdSetScreenDirection(uint16_t dir);
 void lcdSetFontFill(uint16_t color);
 void lcdUnsetFontFill(void);
 void lcdSetFontUnderLine(uint16_t color);


### PR DESCRIPTION
Effectively change the orientation of the screen. All function work as expected relative to the new orientation. Changes are minimal, as basically only the drawing primitives (lcdDrawPixel and lcdDrawFillRect) need to reorient points (mostly everything uses only lcdDrawPixel). When extending, all extending function need to either use the primitives themselves or address the current orientation on their own. The Values of _width and _height remain unchanged.

I guess it might be a good idea to add uint_16_ lcdGetWidth() and uint_16_ lcdGetHeight(), or something alike.